### PR TITLE
Provide static IP as part of the outputs for non-custom domain support when using private VNET

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ A Terraform module to deploy a container app in Azure with the following charact
   - `name` - (Required) The name of the container.
   - `image` - (Required) The container image.
   - `resources` - (Optional) The resource requirements for the container.
-  - `ports` - (Optional) The ports exposed by the container. 
-  - `environment_variables` - (Optional) The environment variables for the container. 
+  - `ports` - (Optional) The ports exposed by the container.
+  - `environment_variables` - (Optional) The environment variables for the container.
   - `command` - (Optional) The command to run within the container in exec form.
   - `args` - (Optional) The arguments to the command in `command` field.
   - `liveness_probe` - (Optional) The liveness probe for the container.
   - `readiness_probe` - (Optional) The readiness probe for the container.
   - `volume_mounts` - (Optional) The volume mounts for the container.
   - `volumes` - (Optional) The volumes for the container.
-  - `secrets` - (Optional) The secrets for the container. 
-  - `image_pull_secrets` - (Optional) The image pull secrets for the container. 
-  - `security_context` - (Optional) The security context for the container. 
-  - `resources` - (Optional) The resource requirements for the container. 
-  - `ports` - (Optional) The ports exposed by the container. 
-  - `environment_variables` - (Optional) The environment variables for the container. 
+  - `secrets` - (Optional) The secrets for the container.
+  - `image_pull_secrets` - (Optional) The image pull secrets for the container.
+  - `security_context` - (Optional) The security context for the container.
+  - `resources` - (Optional) The resource requirements for the container.
+  - `ports` - (Optional) The ports exposed by the container.
+  - `environment_variables` - (Optional) The environment variables for the container.
   - `command` - (Optional) The command to run within the container in exec form.
   - `args` - (Optional) The arguments to the command in `command` field.
   - `liveness_probe` - (Optional) The liveness probe for the container.
@@ -173,4 +173,5 @@ No modules.
 |--------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | <a name="output_container_app_environment_id"></a> [container\_app\_environment\_id](#output\_container\_app\_environment\_id) | The ID of the Container App Environment within which this Container App should exist. |
 | <a name="output_container_app_fqdn"></a> [container\_app\_fqdn](#output\_container\_app\_fqdn)                                 | The FQDN of the Latest Revision of the Container App.                                 |
+| <a name="output_container_app_ips"></a> [container\_app\_ips](#output\_container\_app\_ips)                                    | The IPs of the Latest Revision of the Container App.                                  |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "container_app_fqdn" {
   description = "The FQDN of the Latest Revision of the Container App."
   value       = { for name, container in azurerm_container_app.container_app : name => "https://${container.latest_revision_fqdn}" }
 }
+
+output "container_app_ips" {
+  description = "The IPs of the Latest Revision of the Container App."
+  value       = azurerm_container_app_environment.container_env.static_ip_address
+}


### PR DESCRIPTION
## Describe your changes

When connecting the _container apps_ environment to a private VNET and you're not using _custom domains_ you should configure a private DNS pointing to the ip according to the docs ([link](https://learn.microsoft.com/en-us/azure/container-apps/networking?tabs=azure-cli#dns)), quote:
> Non-custom domains: If you don't plan to use custom domains, create a private DNS zone that resolves the Container Apps environment's default domain to the static IP address of the Container Apps environment. You can use [Azure Private DNS](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview) or your own DNS server. If you use Azure Private DNS, create a Private DNS Zone named as the Container App environment’s default domain (<UNIQUE_IDENTIFIER>.<REGION_NAME>.azurecontainerapps.io), with an A record. The A record contains the name *<DNS Suffix> and the static IP address of the Container Apps environment.
so when using private vnet private DNS can be configured

## Issue number

There is no issue number.

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

