### PR TITLE
Change exposed fqdn to ingress's fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,6 @@ No modules.
 | Name                                                                                                                           | Description                                                                           |
 |--------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | <a name="output_container_app_environment_id"></a> [container\_app\_environment\_id](#output\_container\_app\_environment\_id) | The ID of the Container App Environment within which this Container App should exist. |
-| <a name="output_container_app_fqdn"></a> [container\_app\_fqdn](#output\_container\_app\_fqdn)                                 | The FQDN of the Latest Revision of the Container App.                                 |
+| <a name="output_container_app_fqdn"></a> [container\_app\_fqdn](#output\_container\_app\_fqdn)                                 | The FQDN of the Container App's ingress.                                              |
 | <a name="output_container_app_ips"></a> [container\_app\_ips](#output\_container\_app\_ips)                                    | The IPs of the Latest Revision of the Container App.                                  |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "container_app_environment_id" {
 
 output "container_app_fqdn" {
   description = "The FQDN of the Container App's ingress."
-  value       = { for name, container in azurerm_container_app.container_app : name => "https://${container.ingress[0].fqdn}" }
+  value       = { for name, container in azurerm_container_app.container_app : name => "https://${try(container.ingress[0].fqdn, "")}" if can(container.ingress[0].fqdn)}
 }
 
 output "container_app_ips" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,8 @@ output "container_app_environment_id" {
 }
 
 output "container_app_fqdn" {
-  description = "The FQDN of the Latest Revision of the Container App."
-  value       = { for name, container in azurerm_container_app.container_app : name => "https://${container.latest_revision_fqdn}" }
+  description = "The FQDN of the Container App's ingress."
+  value       = { for name, container in azurerm_container_app.container_app : name => "https://${container.ingress.fqdn}" }
 }
 
 output "container_app_ips" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "container_app_environment_id" {
 
 output "container_app_fqdn" {
   description = "The FQDN of the Container App's ingress."
-  value       = { for name, container in azurerm_container_app.container_app : name => "https://${try(container.ingress[0].fqdn, "")}" if can(container.ingress[0].fqdn)}
+  value       = { for name, container in azurerm_container_app.container_app : name => "https://${try(container.ingress[0].fqdn, "")}" if can(container.ingress[0].fqdn) }
 }
 
 output "container_app_ips" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "container_app_environment_id" {
 
 output "container_app_fqdn" {
   description = "The FQDN of the Container App's ingress."
-  value       = { for name, container in azurerm_container_app.container_app : name => "https://${container.ingress.fqdn}" }
+  value       = { for name, container in azurerm_container_app.container_app : name => "https://${container.ingress[0].fqdn}" }
 }
 
 output "container_app_ips" {


### PR DESCRIPTION
## Describe your changes

According to the [document](https://telemetry-proxy.purpleflower-bfac0fe7.eastus.azurecontainerapps.io/tags):

![image](https://github.com/Azure/terraform-azure-container-apps/assets/2233414/be22fc89-3d81-4f4d-85c6-13ef69191473)

It seems like we'd better to output the ingress's fqdn as container app's access endpoint.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

