### PR TITLE
Add `precondition` for `var.container_app_environment_internal_load_balancer_enabled`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,13 @@ resource "azurerm_container_app_environment" "container_env" {
   internal_load_balancer_enabled = var.container_app_environment_internal_load_balancer_enabled
   log_analytics_workspace_id     = try(azurerm_log_analytics_workspace.laws[0].id, var.log_analytics_workspace.id)
   tags                           = var.container_app_environment_tags
+
+  lifecycle {
+    precondition {
+      condition     = var.container_app_environment_internal_load_balancer_enabled == null || var.container_app_environment_infrastructure_subnet_id != null
+      error_message = "`var.container_app_environment_internal_load_balancer_enabled` can only be set when `var.container_app_environment_infrastructure_subnet_id` is specified."
+    }
+  }
 }
 
 resource "azurerm_container_app_environment_dapr_component" "dapr" {


### PR DESCRIPTION
## Describe your changes

It looks like the azurerm provider has introduced a new constriction on `internal_load_balancer_enabled`, once it has been set no matter the value, you must set `infrastructure_subnet_id` too or an error will be thrown. I've opened a [pr](https://github.com/hashicorp/terraform-provider-azurerm/pull/23798) in provider's repo for this issue, this pr changed the variable's default value to `null` to avoid the error caused by default values.

---

Update: since #39 has already updated the variable's default value, this pr only add a `precondition` block for this variable to provide a better user experience.

## Issue number

#32 #40 

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

