### PR TITLE
Update default value for container_app_environment_internal_load_balancer_enabled

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "container_app_environment_infrastructure_subnet_id" {
 
 variable "container_app_environment_internal_load_balancer_enabled" {
   type        = bool
-  default     = false
+  default     = null
   description = "(Optional) Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. Changing this forces a new resource to be created."
 }
 


### PR DESCRIPTION
This pull request updates the default value for the `container_app_environment_internal_load_balancer_enabled` variable from `false` to `null`. 

With false the azurerm provider was nagging that it wants to have the subnet id:
```
╷
│ Error: Missing required argument
│ 
│   with module.container_apps.azurerm_container_app_environment.container_env,
│   on ../../main.tf line 25, in resource "azurerm_container_app_environment" "container_env":
│   25:   internal_load_balancer_enabled = false
│ 
│ "internal_load_balancer_enabled": all of `infrastructure_subnet_id,internal_load_balancer_enabled` must be specified
```