### PR TITLE
support workload profiles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ resource "azurerm_container_app" "container_app" {
   name                         = each.value.name
   resource_group_name          = var.resource_group_name
   revision_mode                = each.value.revision_mode
+  workload_profile_name        = each.value.workload_profile_name
   tags                         = each.value.tags
 
   template {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "container_apps" {
     name                  = string
     tags                  = optional(map(string))
     revision_mode         = string
-    workload_profile_name = optional(string, "Consumption")
+    workload_profile_name = optional(string)
 
     template = object({
       containers = set(object({

--- a/variables.tf
+++ b/variables.tf
@@ -6,9 +6,10 @@ variable "container_app_environment_name" {
 
 variable "container_apps" {
   type = map(object({
-    name          = string
-    tags          = optional(map(string))
-    revision_mode = string
+    name                  = string
+    tags                  = optional(map(string))
+    revision_mode         = string
+    workload_profile_name = optional(string, "Consumption")
 
     template = object({
       containers = set(object({

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.11, < 4.0"
+      version = ">= 3.85, < 4.0"
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

Support workload profiles, this is new in https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.85.0
This will also avoid continuous drift, else you'll get:
```
      - workload_profile_name         = "Consumption" -> null
```

## Issue number

#000

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [X] I have passed pr-check on my machine

Thanks for your cooperation!

