### PR TITLE
Remove duplicate parameter descriptions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ A Terraform module to deploy a container app in Azure with the following charact
   - `secrets` - (Optional) The secrets for the container.
   - `image_pull_secrets` - (Optional) The image pull secrets for the container.
   - `security_context` - (Optional) The security context for the container.
-  - `resources` - (Optional) The resource requirements for the container.
-  - `ports` - (Optional) The ports exposed by the container.
-  - `environment_variables` - (Optional) The environment variables for the container.
-  - `command` - (Optional) The command to run within the container in exec form.
-  - `args` - (Optional) The arguments to the command in `command` field.
-  - `liveness_probe` - (Optional) The liveness probe for the container.
 
 
 ## Usage in Terraform 1.2.0


### PR DESCRIPTION
## Describe your changes

The readme has duplicate parameter descriptions for
  - `resources`
  - `ports`
  - `environment_variables`
  - `command`
  - `args`
  - `liveness_probe`

## Issue number

#000

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

